### PR TITLE
Add host_aliases for known bitbucket IP addresses

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 class bitbucket_org {
 	sshkey { 'bitbucket.org':
-		ensure => present,
-		key    => 'AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==',
-		type   => 'ssh-rsa'
+		ensure       => present,
+                host_aliases => ['131.103.20.167', '131.103.20.168', '131.103.20.169', '131.103.20.170'],
+		key          => 'AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==',
+		type         => 'ssh-rsa'
 	}
 }


### PR DESCRIPTION
Bitbucket lists their known IP addresses on [confluence](https://confluence.atlassian.com/bitbucket/what-are-the-bitbucket-ip-addresses-i-should-use-to-configure-my-corporate-firewall-343343385.html). Without defining
these IP addresses as host_aliases, using mercurial over ssh issues a warning to
the console:

```
Warning: Permanently added the RSA host key for IP address '131.103.20.167' to the list of known hosts.
```
