### PR TITLE
Correct Mode of /etc/ssh/ssh_known_hosts

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,4 +4,11 @@ class bitbucket_org {
 		key    => 'AAAAB3NzaC1yc2EAAAABIwAAAQEAubiN81eDcafrgMeLzaFPsw2kNvEcqTKl/VqLat/MaB33pZy0y3rJZtnqwR2qOOvbwKZYKiEO1O6VqNEBxKvJJelCq0dTXWT5pbO2gDXC6h6QDXCaHo6pOHGPUy+YBaGQRGuSusMEASYiWunYN0vCAI8QaXnWMXNMdFP3jHAJH0eDsoiGnLPBlBp4TNm6rYI74nMzgz3B9IikW4WVK+dc8KZJZWYjAuORU3jc1c/NPskD2ASinf8v3xnfXeukU0sJ5N6m5E8VLjObPEO+mN2t/FZTMZLiFqPWc/ALSqnMnnhwrNi2rbfg/rd/IpL8Le3pSBne8+seeFVBoGqzHM9yXw==',
 		type   => 'ssh-rsa'
 	}
+
+	file { '/etc/ssh/ssh_known_hosts':
+		ensure => file,
+		mode   => '0644',
+		owner  => 'root',
+		group  => 'root',
+	}
 }


### PR DESCRIPTION
There is a [bug](https://tickets.puppetlabs.com/browse/PUP-2900) in the `sshkey` resource that creates the resource with
mode 0600, making this global file unreadable for other users. By defining the
file resource with the expected mode, non-root users of this module can hit
the ground running.

I ran into this confusing issue when provisioning a CI machine, which runs scm as its own user and without sudo. While I'd prefer to get the fix in puppet itself, this stopgap solution would allow the module to work in most cases.
